### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/FelixTheC/py-overload/security/code-scanning/3](https://github.com/FelixTheC/py-overload/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root so all jobs get least-privilege defaults unless they override them.  
Best single fix here: insert:

```yaml
permissions:
  contents: read
```

right after the `on:` trigger section and before `jobs:`. This fixes the flagged `setup` job without changing behavior. The existing `deploy` job-level permissions remain in effect (job-level overrides root-level), so `id-token: write` for PyPI publish continues to work.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
